### PR TITLE
Consolidate detection of required but missing fields in bindForm().

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -1,8 +1,8 @@
 package binding
 
 import (
-	"testing"
 	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 func TestBind(t *testing.T) {
@@ -49,6 +49,17 @@ func TestBind(t *testing.T) {
 
 		})
 
+		Convey("Missing one required field", t, func() {
+
+			Convey("A Required error should be produced", nil)
+
+		})
+
+		Convey("Missing multiple required fields", t, func() {
+
+			Convey("As many Required errors should be produced", nil)
+
+		})
 	})
 
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,8 +1,8 @@
 package binding
 
 import (
-	"testing"
 	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 func TestValidate(t *testing.T) {
@@ -10,18 +10,6 @@ func TestValidate(t *testing.T) {
 	Convey("Given a struct populated properly and as expected", t, func() {
 
 		Convey("No errors should be produced", nil)
-
-	})
-
-	Convey("Given a populated struct missing one required field", t, func() {
-
-		Convey("A Required error should be produced", nil)
-
-	})
-
-	Convey("Given a populated struct missing multiple required fields", t, func() {
-
-		Convey("As many Required errors should be produced", nil)
 
 	})
 


### PR DESCRIPTION
Avoids a second pass in Validate(), where it is much harder to tell
a missing field from its (or its pointer's) 'zero value'.

closes #4
