### PR TITLE
fix validation of bool types

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -193,7 +193,7 @@ func Validate(req *http.Request, userStruct FieldMapper) Errors {
 					addRequiredError()
 				}
 			case *bool:
-				if !*t == false {
+				if *t == false {
 					addRequiredError()
 				}
 			case *[]bool:


### PR DESCRIPTION
This one is pretty self-explanatory; the logic for validating bool types was reversed. It looks like it was probably just a typo.

I found it while writing tests for the #9 implementation. It's fixed there, too, but I thought it was important and small enough that it made sense to submit it separately.
