### PR TITLE
Added Map to support mux.Vars in Gorilla

### DIFF
--- a/bindfield.go
+++ b/bindfield.go
@@ -1,0 +1,317 @@
+package binding
+
+import (
+	"errors"
+	"mime/multipart"
+	"strconv"
+	"time"
+)
+
+type errorHandler func(err error)
+
+func bindFormField(
+	fieldPointer interface{},
+	fieldName string,
+	fieldSpec Field,
+	strs []string,
+	formData map[string][]string,
+	formFile map[string][]*multipart.FileHeader,
+	errorHandler errorHandler,
+) {
+	switch t := fieldPointer.(type) {
+	case **multipart.FileHeader:
+		if files, ok := formFile[fieldName]; ok {
+			*t = files[0]
+		}
+	case *[]**multipart.FileHeader:
+		if files, ok := formFile[fieldName]; ok {
+			for _, file := range files {
+				*t = append(*t, &file)
+			}
+		}
+	default:
+		bindField(fieldPointer, fieldName, fieldSpec, strs, errorHandler)
+	}
+}
+
+func bindField(
+	fieldPointer interface{},
+	fieldName string,
+	fieldSpec Field,
+	strs []string,
+	errorHandler errorHandler,
+) {
+	switch t := fieldPointer.(type) {
+	case *uint8:
+		val, err := strconv.ParseUint(strs[0], 10, 8)
+		errorHandler(err)
+		*t = uint8(val)
+	case **uint8:
+		parsed, err := strconv.ParseUint(strs[0], 10, 8)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := uint8(parsed)
+		*t = &val
+	case *[]uint8:
+		for _, str := range strs {
+			val, err := strconv.ParseUint(str, 10, 8)
+			errorHandler(err)
+			*t = append(*t, uint8(val))
+		}
+	case *uint16:
+		val, err := strconv.ParseUint(strs[0], 10, 16)
+		errorHandler(err)
+		*t = uint16(val)
+	case **uint16:
+		parsed, err := strconv.ParseUint(strs[0], 10, 16)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := uint16(parsed)
+		*t = &val
+	case *[]uint16:
+		for _, str := range strs {
+			val, err := strconv.ParseUint(str, 10, 16)
+			errorHandler(err)
+			*t = append(*t, uint16(val))
+		}
+	case *uint32:
+		val, err := strconv.ParseUint(strs[0], 10, 32)
+		errorHandler(err)
+		*t = uint32(val)
+	case **uint32:
+		parsed, err := strconv.ParseUint(strs[0], 10, 32)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := uint32(parsed)
+		*t = &val
+	case *[]uint32:
+		for _, str := range strs {
+			val, err := strconv.ParseUint(str, 10, 32)
+			errorHandler(err)
+			*t = append(*t, uint32(val))
+		}
+	case *uint64:
+		val, err := strconv.ParseUint(strs[0], 10, 64)
+		errorHandler(err)
+		*t = val
+	case **uint64:
+		parsed, err := strconv.ParseUint(strs[0], 10, 64)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := uint64(parsed)
+		*t = &val
+	case *[]uint64:
+		for _, str := range strs {
+			val, err := strconv.ParseUint(str, 10, 64)
+			errorHandler(err)
+			*t = append(*t, uint64(val))
+		}
+	case *int8:
+		val, err := strconv.ParseInt(strs[0], 10, 8)
+		errorHandler(err)
+		*t = int8(val)
+	case **int8:
+		parsed, err := strconv.ParseInt(strs[0], 10, 8)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := int8(parsed)
+		*t = &val
+	case *[]int8:
+		for _, str := range strs {
+			val, err := strconv.ParseInt(str, 10, 8)
+			errorHandler(err)
+			*t = append(*t, int8(val))
+		}
+	case *int16:
+		val, err := strconv.ParseInt(strs[0], 10, 16)
+		errorHandler(err)
+		*t = int16(val)
+	case **int16:
+		parsed, err := strconv.ParseInt(strs[0], 10, 16)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := int16(parsed)
+		*t = &val
+	case *[]int16:
+		for _, str := range strs {
+			val, err := strconv.ParseInt(str, 10, 16)
+			errorHandler(err)
+			*t = append(*t, int16(val))
+		}
+	case *int32:
+		val, err := strconv.ParseInt(strs[0], 10, 32)
+		errorHandler(err)
+		*t = int32(val)
+	case **int32:
+		parsed, err := strconv.ParseInt(strs[0], 10, 32)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := int32(parsed)
+		*t = &val
+	case *[]int32:
+		for _, str := range strs {
+			val, err := strconv.ParseInt(str, 10, 32)
+			errorHandler(err)
+			*t = append(*t, int32(val))
+		}
+	case *int64:
+		val, err := strconv.ParseInt(strs[0], 10, 64)
+		errorHandler(err)
+		*t = val
+	case **int64:
+		parsed, err := strconv.ParseInt(strs[0], 10, 64)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := int64(parsed)
+		*t = &val
+	case *[]int64:
+		for _, str := range strs {
+			val, err := strconv.ParseInt(str, 10, 64)
+			errorHandler(err)
+			*t = append(*t, int64(val))
+		}
+	case *float32:
+		val, err := strconv.ParseFloat(strs[0], 32)
+		errorHandler(err)
+		*t = float32(val)
+	case **float32:
+		parsed, err := strconv.ParseFloat(strs[0], 32)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := float32(parsed)
+		*t = &val
+	case *[]float32:
+		for _, str := range strs {
+			val, err := strconv.ParseFloat(str, 32)
+			errorHandler(err)
+			*t = append(*t, float32(val))
+		}
+	case *float64:
+		val, err := strconv.ParseFloat(strs[0], 64)
+		errorHandler(err)
+		*t = val
+	case **float64:
+		parsed, err := strconv.ParseFloat(strs[0], 64)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := float64(parsed)
+		*t = &val
+	case *[]float64:
+		for _, str := range strs {
+			val, err := strconv.ParseFloat(str, 64)
+			errorHandler(err)
+			*t = append(*t, val)
+		}
+	case *uint:
+		val, err := strconv.ParseUint(strs[0], 10, 0)
+		errorHandler(err)
+		*t = uint(val)
+	case **uint:
+		parsed, err := strconv.ParseUint(strs[0], 10, 0)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := uint(parsed)
+		*t = &val
+	case *[]uint:
+		for _, str := range strs {
+			val, err := strconv.ParseUint(str, 10, 0)
+			errorHandler(err)
+			*t = append(*t, uint(val))
+		}
+	case *int:
+		val, err := strconv.ParseInt(strs[0], 10, 0)
+		errorHandler(err)
+		*t = int(val)
+	case **int:
+		parsed, err := strconv.ParseInt(strs[0], 10, 0)
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		val := int(parsed)
+		*t = &val
+	case *[]int:
+		for _, str := range strs {
+			val, err := strconv.ParseInt(str, 10, 0)
+			errorHandler(err)
+			*t = append(*t, int(val))
+		}
+	case *bool:
+		val, err := strconv.ParseBool(strs[0])
+		errorHandler(err)
+		*t = val
+	case **bool:
+		val, err := strconv.ParseBool(strs[0])
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		*t = &val
+	case *[]bool:
+		for _, str := range strs {
+			val, err := strconv.ParseBool(str)
+			errorHandler(err)
+			*t = append(*t, val)
+		}
+	case *string:
+		*t = strs[0]
+	case **string:
+		s := strs[0]
+		*t = &s
+	case *[]string:
+		*t = strs
+	case *time.Time:
+		timeFormat := TimeFormat
+		if fieldSpec.TimeFormat != "" {
+			timeFormat = fieldSpec.TimeFormat
+		}
+		val, err := time.Parse(timeFormat, strs[0])
+		errorHandler(err)
+		*t = val
+	case **time.Time:
+		timeFormat := TimeFormat
+		if fieldSpec.TimeFormat != "" {
+			timeFormat = fieldSpec.TimeFormat
+		}
+		val, err := time.Parse(timeFormat, strs[0])
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		*t = &val
+	case *[]time.Time:
+		timeFormat := TimeFormat
+		if fieldSpec.TimeFormat != "" {
+			timeFormat = fieldSpec.TimeFormat
+		}
+		for _, str := range strs {
+			val, err := time.Parse(timeFormat, str)
+			errorHandler(err)
+			*t = append(*t, val)
+		}
+	default:
+		errorHandler(errors.New("Field type is unsupported by the application"))
+	}
+}

--- a/binding.go
+++ b/binding.go
@@ -5,11 +5,9 @@ package binding
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -371,290 +369,15 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 			continue
 		}
 
-		switch t := fieldPointer.(type) {
-		case *uint8:
-			val, err := strconv.ParseUint(strs[0], 10, 8)
-			errorHandler(err)
-			*t = uint8(val)
-		case **uint8:
-			parsed, err := strconv.ParseUint(strs[0], 10, 8)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := uint8(parsed)
-			*t = &val
-		case *[]uint8:
-			for _, str := range strs {
-				val, err := strconv.ParseUint(str, 10, 8)
-				errorHandler(err)
-				*t = append(*t, uint8(val))
-			}
-		case *uint16:
-			val, err := strconv.ParseUint(strs[0], 10, 16)
-			errorHandler(err)
-			*t = uint16(val)
-		case **uint16:
-			parsed, err := strconv.ParseUint(strs[0], 10, 16)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := uint16(parsed)
-			*t = &val
-		case *[]uint16:
-			for _, str := range strs {
-				val, err := strconv.ParseUint(str, 10, 16)
-				errorHandler(err)
-				*t = append(*t, uint16(val))
-			}
-		case *uint32:
-			val, err := strconv.ParseUint(strs[0], 10, 32)
-			errorHandler(err)
-			*t = uint32(val)
-		case **uint32:
-			parsed, err := strconv.ParseUint(strs[0], 10, 32)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := uint32(parsed)
-			*t = &val
-		case *[]uint32:
-			for _, str := range strs {
-				val, err := strconv.ParseUint(str, 10, 32)
-				errorHandler(err)
-				*t = append(*t, uint32(val))
-			}
-		case *uint64:
-			val, err := strconv.ParseUint(strs[0], 10, 64)
-			errorHandler(err)
-			*t = val
-		case **uint64:
-			parsed, err := strconv.ParseUint(strs[0], 10, 64)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := uint64(parsed)
-			*t = &val
-		case *[]uint64:
-			for _, str := range strs {
-				val, err := strconv.ParseUint(str, 10, 64)
-				errorHandler(err)
-				*t = append(*t, uint64(val))
-			}
-		case *int8:
-			val, err := strconv.ParseInt(strs[0], 10, 8)
-			errorHandler(err)
-			*t = int8(val)
-		case **int8:
-			parsed, err := strconv.ParseInt(strs[0], 10, 8)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := int8(parsed)
-			*t = &val
-		case *[]int8:
-			for _, str := range strs {
-				val, err := strconv.ParseInt(str, 10, 8)
-				errorHandler(err)
-				*t = append(*t, int8(val))
-			}
-		case *int16:
-			val, err := strconv.ParseInt(strs[0], 10, 16)
-			errorHandler(err)
-			*t = int16(val)
-		case **int16:
-			parsed, err := strconv.ParseInt(strs[0], 10, 16)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := int16(parsed)
-			*t = &val
-		case *[]int16:
-			for _, str := range strs {
-				val, err := strconv.ParseInt(str, 10, 16)
-				errorHandler(err)
-				*t = append(*t, int16(val))
-			}
-		case *int32:
-			val, err := strconv.ParseInt(strs[0], 10, 32)
-			errorHandler(err)
-			*t = int32(val)
-		case **int32:
-			parsed, err := strconv.ParseInt(strs[0], 10, 32)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := int32(parsed)
-			*t = &val
-		case *[]int32:
-			for _, str := range strs {
-				val, err := strconv.ParseInt(str, 10, 32)
-				errorHandler(err)
-				*t = append(*t, int32(val))
-			}
-		case *int64:
-			val, err := strconv.ParseInt(strs[0], 10, 64)
-			errorHandler(err)
-			*t = val
-		case **int64:
-			parsed, err := strconv.ParseInt(strs[0], 10, 64)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := int64(parsed)
-			*t = &val
-		case *[]int64:
-			for _, str := range strs {
-				val, err := strconv.ParseInt(str, 10, 64)
-				errorHandler(err)
-				*t = append(*t, int64(val))
-			}
-		case *float32:
-			val, err := strconv.ParseFloat(strs[0], 32)
-			errorHandler(err)
-			*t = float32(val)
-		case **float32:
-			parsed, err := strconv.ParseFloat(strs[0], 32)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := float32(parsed)
-			*t = &val
-		case *[]float32:
-			for _, str := range strs {
-				val, err := strconv.ParseFloat(str, 32)
-				errorHandler(err)
-				*t = append(*t, float32(val))
-			}
-		case *float64:
-			val, err := strconv.ParseFloat(strs[0], 64)
-			errorHandler(err)
-			*t = val
-		case **float64:
-			parsed, err := strconv.ParseFloat(strs[0], 64)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := float64(parsed)
-			*t = &val
-		case *[]float64:
-			for _, str := range strs {
-				val, err := strconv.ParseFloat(str, 64)
-				errorHandler(err)
-				*t = append(*t, val)
-			}
-		case *uint:
-			val, err := strconv.ParseUint(strs[0], 10, 0)
-			errorHandler(err)
-			*t = uint(val)
-		case **uint:
-			parsed, err := strconv.ParseUint(strs[0], 10, 0)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := uint(parsed)
-			*t = &val
-		case *[]uint:
-			for _, str := range strs {
-				val, err := strconv.ParseUint(str, 10, 0)
-				errorHandler(err)
-				*t = append(*t, uint(val))
-			}
-		case *int:
-			val, err := strconv.ParseInt(strs[0], 10, 0)
-			errorHandler(err)
-			*t = int(val)
-		case **int:
-			parsed, err := strconv.ParseInt(strs[0], 10, 0)
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			val := int(parsed)
-			*t = &val
-		case *[]int:
-			for _, str := range strs {
-				val, err := strconv.ParseInt(str, 10, 0)
-				errorHandler(err)
-				*t = append(*t, int(val))
-			}
-		case *bool:
-			val, err := strconv.ParseBool(strs[0])
-			errorHandler(err)
-			*t = val
-		case **bool:
-			val, err := strconv.ParseBool(strs[0])
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			*t = &val
-		case *[]bool:
-			for _, str := range strs {
-				val, err := strconv.ParseBool(str)
-				errorHandler(err)
-				*t = append(*t, val)
-			}
-		case *string:
-			*t = strs[0]
-		case **string:
-			s := strs[0]
-			*t = &s
-		case *[]string:
-			*t = strs
-		case *time.Time:
-			timeFormat := TimeFormat
-			if fieldSpec.TimeFormat != "" {
-				timeFormat = fieldSpec.TimeFormat
-			}
-			val, err := time.Parse(timeFormat, strs[0])
-			errorHandler(err)
-			*t = val
-		case **time.Time:
-			timeFormat := TimeFormat
-			if fieldSpec.TimeFormat != "" {
-				timeFormat = fieldSpec.TimeFormat
-			}
-			val, err := time.Parse(timeFormat, strs[0])
-			if err != nil {
-				errorHandler(err)
-				continue
-			}
-			*t = &val
-		case *[]time.Time:
-			timeFormat := TimeFormat
-			if fieldSpec.TimeFormat != "" {
-				timeFormat = fieldSpec.TimeFormat
-			}
-			for _, str := range strs {
-				val, err := time.Parse(timeFormat, str)
-				errorHandler(err)
-				*t = append(*t, val)
-			}
-		case **multipart.FileHeader:
-			if files, ok := formFile[fieldName]; ok {
-				*t = files[0]
-			}
-		case *[]**multipart.FileHeader:
-			if files, ok := formFile[fieldName]; ok {
-				for _, file := range files {
-					*t = append(*t, &file)
-				}
-			}
-		default:
-			errorHandler(errors.New("Field type is unsupported by the application"))
-		}
-
+		bindFormField(
+			fieldPointer,
+			fieldName,
+			fieldSpec,
+			strs,
+			formData,
+			formFile,
+			errorHandler,
+		)
 	}
 
 	errs = append(errs, Validate(req, userStruct)...)
@@ -674,6 +397,45 @@ func fieldNameAndSpec(fieldNameOrSpec interface{}) (string, bool, Field) {
 	}
 
 	return fieldName, fieldHasSpec, fieldSpec
+}
+
+func SliceMap(req *http.Request, userStruct FieldMapper, sm map[string][]string) Errors {
+	fm := userStruct.FieldMap()
+	errs := Errors{}
+
+	for fieldPointer, fieldNameOrSpec := range fm {
+		fieldName, _, fieldSpec := fieldNameAndSpec(fieldNameOrSpec)
+		strs := sm[fieldName]
+
+		errorHandler := func(err error) {
+			if err != nil {
+				errs.Add([]string{fieldName}, TypeError, err.Error())
+			}
+		}
+
+		if fieldSpec.Binder != nil {
+			errs = fieldSpec.Binder(fieldName, strs, errs)
+			continue
+		}
+
+		bindField(
+			fieldPointer,
+			fieldName,
+			fieldSpec,
+			strs,
+			errorHandler,
+		)
+	}
+
+	return append(errs, Validate(req, userStruct)...)
+}
+
+func Map(req *http.Request, userStruct FieldMapper, m map[string]string) Errors {
+	sm := map[string][]string{}
+	for k, v := range m {
+		sm[k] = []string{v}
+	}
+	return SliceMap(req, userStruct, sm)
 }
 
 type (


### PR DESCRIPTION
I suggest to add `Map()` which works like `Form()` or `Json()` but takes map[string]string.

It is make possible to bind the route variables (given by [mux.Vars](http://www.gorillatoolkit.org/pkg/mux#Vars)) in similar way to parameters. It is useful for me.
