### PR TITLE
Issue #23 - add multipart/form-data usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,77 @@ func main() {
 }
 ```
 
+Multipart/form-data usage example
+---------------------------------
+
+```go
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/mholt/binding"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+)
+
+// We expect a multipart/form-data upload with
+// a file field named 'data'
+type MultipartForm struct {
+	Data *multipart.FileHeader `json:"data"`
+}
+
+func (f *MultipartForm) FieldMap() binding.FieldMap {
+	return binding.FieldMap{
+		&f.Data: "data",
+	}
+}
+
+// Handlers are still clean and simple
+func handler(resp http.ResponseWriter, req *http.Request) {
+	multipartForm := new(MultipartForm)
+	errs := binding.Bind(req, multipartForm)
+	if errs.Handle(resp) {
+		return
+	}
+
+	// To access the file data you need to Open the file
+	// handler and read the bytes out.
+	var fh io.ReadCloser
+	var err error
+	if fh, err = multipartForm.Data.Open(); err != nil {
+		http.Error(resp,
+			fmt.Sprint("Error opening Mime::Data %+v", err),
+			http.StatusInternalServerError)
+		return
+	}
+	defer fh.Close()
+	dataBytes := bytes.Buffer{}
+	var size int64
+	if size, err = dataBytes.ReadFrom(fh); err != nil {
+		http.Error(resp,
+			fmt.Sprint("Error reading Mime::Data %+v", err),
+			http.StatusInternalServerError)
+		return
+	}
+	// Now you have the attachment in databytes.
+	// Maximum size is default is 10MB.
+	log.Printf("Read %v bytes with filename %s",
+		size, multipartForm.Data.Filename)
+}
+
+func main() {
+	http.HandleFunc("/upload", handler)
+	http.ListenAndServe(":3000", nil)
+}
+
+```
+
+You can test from CLI using the excellent httpie client
+
+   `http -f POST localhost:3000/upload data@myupload`
 
 Custom data validation
 -----------------------


### PR DESCRIPTION
Adding a working example of a handler which implements multipart/form-data handling using binding.
