### PR TITLE
implement idiomatic errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ For types you've defined, you can bind form data to it by implementing the `Bind
 ```go
 type MyType map[string]string
 
-func (t *MyType) Bind(fieldName string, strVals []string) error {
+func (t MyType) Bind(fieldName string, strVals []string) error {
 	t["formData"] = strVals[0]
 	return nil
 }
@@ -212,8 +212,7 @@ func (t *MyType) FieldMap() binding.FieldMap {
 }
 ```
 
-Notice that the `binding.Errors` type has a convenience method `.Add()` which you can use to append to the slice if you prefer.
-
+The `Errors` type has a convenience method, `Add`, which you can use to append to the slice if you prefer.
 
 Supported types (forms)
 ------------------------

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ func handler(resp http.ResponseWriter, req *http.Request) {
 	var err error
 	if fh, err = multipartForm.Data.Open(); err != nil {
 		http.Error(resp,
-			fmt.Sprint("Error opening Mime::Data %+v", err),
+			fmt.Sprint("Error opening Mime::Data %v", err),
 			http.StatusInternalServerError)
 		return
 	}
@@ -131,7 +131,7 @@ func handler(resp http.ResponseWriter, req *http.Request) {
 	var size int64
 	if size, err = dataBytes.ReadFrom(fh); err != nil {
 		http.Error(resp,
-			fmt.Sprint("Error reading Mime::Data %+v", err),
+			fmt.Sprint("Error reading Mime::Data %v", err),
 			http.StatusInternalServerError)
 		return
 	}

--- a/README.md
+++ b/README.md
@@ -161,11 +161,7 @@ You may optionally have your type implement the `binding.Validator` interface to
 func (cf ContactForm) Validate(req *http.Request) error {
 	if cf.Message == "Go needs generics" {
 		return binding.Errors{
-			binding.Error{
-				FieldNames:     []string{"message"},
-				Classification: "ComplaintError",
-				Message:        "Go has generics. They're called interfaces.",
-			},
+			binding.NewError([]string{"message"}, "ComplaintError", "Go has generics. They're called interfaces.")
 		}
 	}
 	return nil
@@ -196,15 +192,11 @@ func (t *MyType) FieldMap() binding.FieldMap {
 	return binding.FieldMap{
 		"number": binding.Field{
 			Binder: func(fieldName string, formVals []string) error {
-				errs := binding.Errors{}
 				val, err := strconv.Atoi(formVals[0])
 				if err != nil {
-					errs.Add([]string{fieldName}, binding.DeserializationError, err.Error())
+					return binding.Errors{binding.NewError([]string{fieldName}, binding.DeserializationError, err.Error())}
 				}
 				t.SomeNumber = val
-				if errs.Len() > 0 {
-					return errs
-				}
 				return nil
 			},
 		},

--- a/README.md
+++ b/README.md
@@ -66,9 +66,8 @@ func (cf *ContactForm) FieldMap() binding.FieldMap {
 // Now your handlers can stay clean and simple
 func handler(resp http.ResponseWriter, req *http.Request) {
 	contactForm := new(ContactForm)
-	if errs := binding.Bind(req, contactForm); err != nil {
-		e := errs.(binding.Errors)
-		e.Handle(resp)
+	if errs := binding.Bind(req, contactForm); errs != nil {
+		http.Error(resp, errs.Error(), http.StatusBadRequest)
 		return
 	}
 	fmt.Fprintf(resp, "From:    %d\n", contactForm.User.ID)
@@ -113,8 +112,7 @@ func (f *MultipartForm) FieldMap() binding.FieldMap {
 func handler(resp http.ResponseWriter, req *http.Request) {
 	multipartForm := new(MultipartForm)
 	if errs := binding.Bind(req, multipartForm); errs != nil {
-		e := errs.(binding.Errors)
-		e.Handle(resp)
+		http.Error(resp, errs.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -173,24 +171,6 @@ func (cf ContactForm) Validate(req *http.Request) error {
 	return nil
 }
 ```
-
-
-
-Error Handling
----------------
-
-`binding.Bind()` and each deserializer returns errors. You don't have to use them, but the `binding.Errors` type comes with a kind of built-in "handler" to write the errors to the response as JSON for you. For example, you might do this in your HTTP handler:
-
-```go
-if errs := binding.Bind(req, contactForm); errs != nil {
-	e := errs.(binding.Errors)
-	if e.Handle(resp) {
-		return
-	}
-}
-```
-
-As you can see, if `.Handle(resp)` wrote errors to the response, your handler may gracefully exit.
 
 
 

--- a/bind_test.go
+++ b/bind_test.go
@@ -2,7 +2,6 @@ package binding
 
 import (
 	"bytes"
-	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -149,7 +148,7 @@ func TestBindForm(t *testing.T) {
 				req, err := http.NewRequest("POST", "http://www.example.com", nil)
 				So(err, ShouldBeNil)
 				var errs Errors
-				errs = bindForm(req, &actual, formData, nil, errs)
+				errs = bindForm(req, &actual, formData, nil)
 				Convey("Then all of the struct's fields should be populated", func() {
 					Convey("Then the Uint8 field should have the expected value", func() {
 						So(actual.Uint8, ShouldEqual, expected.Uint8)
@@ -337,7 +336,7 @@ func TestBindForm(t *testing.T) {
 					So(errs.Len(), ShouldEqual, 0)
 					if errs.Len() > 0 {
 						for _, e := range errs {
-							Println(fmt.Sprintf("%v. %s", e.FieldNames, e.Message))
+							t.Logf("%v. %s", e.Field(), e.Error())
 						}
 					}
 				})

--- a/bind_test.go
+++ b/bind_test.go
@@ -336,7 +336,7 @@ func TestBindForm(t *testing.T) {
 					So(errs.Len(), ShouldEqual, 0)
 					if errs.Len() > 0 {
 						for _, e := range errs {
-							t.Logf("%v. %s", e.Field(), e.Error())
+							t.Logf("%v. %s", e.Fields(), e.Error())
 						}
 					}
 				})

--- a/binding.go
+++ b/binding.go
@@ -48,7 +48,7 @@ func Bind(req *http.Request, userStruct FieldMapper) error {
 	}
 
 	if len(errs) > 0 {
-		return &errs
+		return errs
 	}
 	return nil
 }

--- a/binding.go
+++ b/binding.go
@@ -365,7 +365,7 @@ func validate(req *http.Request, userStruct FieldMapper) Errors {
 		err := validator.Validate(req)
 		if err != nil {
 			switch e := err.(type) {
-			case FieldError:
+			case Error:
 				errs = append(errs, e)
 			case Errors:
 				errs = append(errs, e...)
@@ -404,7 +404,7 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 				err := binder.Bind(fieldName, strs)
 				if err != nil {
 					switch e := err.(type) {
-					case FieldError:
+					case Error:
 						errs = append(errs, e)
 					case Errors:
 						errs = append(errs, e...)
@@ -426,7 +426,7 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 			err := fieldSpec.Binder(fieldName, strs)
 			if err != nil {
 				switch e := err.(type) {
-				case FieldError:
+				case Error:
 					errs = append(errs, e)
 				case Errors:
 					errs = append(errs, e...)

--- a/binding.go
+++ b/binding.go
@@ -79,8 +79,13 @@ func defaultFormBinder(req *http.Request, userStruct FieldMapper) Errors {
 
 // URL reads data out of the query string into a struct you provide.
 // This function invokes data validation after deserialization.
-func URL(req *http.Request, userStruct FieldMapper) Errors {
-	return urlBinder(req, userStruct)
+func URL(req *http.Request, userStruct FieldMapper) error {
+	err := urlBinder(req, userStruct)
+	if len(err) > 0 {
+		return err
+	}
+	return nil
+
 }
 
 var urlBinder requestBinder = defaultURLBinder

--- a/binding.go
+++ b/binding.go
@@ -742,7 +742,6 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 		default:
 			errorHandler(errors.New("Field type is unsupported by the application"))
 		}
-
 	}
 
 	return validate(errs, req, userStruct)

--- a/binding.go
+++ b/binding.go
@@ -19,6 +19,8 @@ type requestBinder func(req *http.Request, userStruct FieldMapper) Errors
 // Bind takes data out of the request and deserializes into a struct according
 // to the Content-Type of the request. If no Content-Type is specified, there
 // better be data in the query string, otherwise an error will be produced.
+//
+// A non-nil return value may be an Errors value.
 func Bind(req *http.Request, userStruct FieldMapper) error {
 	var errs Errors
 

--- a/binding.go
+++ b/binding.go
@@ -40,11 +40,11 @@ func Bind(req *http.Request, userStruct FieldMapper) error {
 		if len(req.URL.Query()) > 0 {
 			return Form(req, userStruct)
 		} else {
-			errs.Add("", ContentTypeError, "Empty Content-Type")
+			errs.Add([]string{}, ContentTypeError, "Empty Content-Type")
 			errs = append(errs, validate(req, userStruct)...)
 		}
 	} else {
-		errs.Add("", ContentTypeError, "Unsupported Content-Type")
+		errs.Add([]string{}, ContentTypeError, "Unsupported Content-Type")
 	}
 
 	if len(errs) > 0 {
@@ -70,7 +70,7 @@ func defaultFormBinder(req *http.Request, userStruct FieldMapper) Errors {
 
 	parseErr := req.ParseForm()
 	if parseErr != nil {
-		errs.Add("", DeserializationError, parseErr.Error())
+		errs.Add([]string{}, DeserializationError, parseErr.Error())
 		return errs
 	}
 
@@ -96,13 +96,13 @@ func defaultMultipartFormBinder(req *http.Request, userStruct FieldMapper) Error
 
 	multipartReader, err := req.MultipartReader()
 	if err != nil {
-		errs.Add("", DeserializationError, err.Error())
+		errs.Add([]string{}, DeserializationError, err.Error())
 		return errs
 	}
 
 	form, parseErr := multipartReader.ReadForm(MaxMemory)
 	if parseErr != nil {
-		errs.Add("", DeserializationError, parseErr.Error())
+		errs.Add([]string{}, DeserializationError, parseErr.Error())
 		return errs
 	}
 
@@ -132,11 +132,11 @@ func defaultJsonBinder(req *http.Request, userStruct FieldMapper) Errors {
 		defer req.Body.Close()
 		err := json.NewDecoder(req.Body).Decode(userStruct)
 		if err != nil && err != io.EOF {
-			errs.Add("", DeserializationError, err.Error())
+			errs.Add([]string{}, DeserializationError, err.Error())
 			return errs
 		}
 	} else {
-		errs.Add("", DeserializationError, "Empty request body")
+		errs.Add([]string{}, DeserializationError, "Empty request body")
 		return errs
 	}
 
@@ -173,7 +173,7 @@ func validate(req *http.Request, userStruct FieldMapper) Errors {
 		}
 
 		addRequiredError := func() {
-			errs.Add(fieldName, RequiredError, "Required")
+			errs.Add([]string{fieldName}, RequiredError, "Required")
 		}
 		if fieldSpec.Required {
 			switch t := fieldPointer.(type) {
@@ -370,7 +370,7 @@ func validate(req *http.Request, userStruct FieldMapper) Errors {
 			case Errors:
 				errs = append(errs, e...)
 			default:
-				errs.Add("", "", e.Error())
+				errs.Add([]string{}, "", e.Error())
 			}
 		}
 	}
@@ -409,7 +409,7 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 					case Errors:
 						errs = append(errs, e...)
 					default:
-						errs.Add(fieldName, "", e.Error())
+						errs.Add([]string{fieldName}, "", e.Error())
 					}
 				}
 				continue
@@ -418,7 +418,7 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 
 		errorHandler := func(err error) {
 			if err != nil {
-				errs.Add(fieldName, TypeError, err.Error())
+				errs.Add([]string{fieldName}, TypeError, err.Error())
 			}
 		}
 
@@ -431,7 +431,7 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 				case Errors:
 					errs = append(errs, e...)
 				default:
-					errs.Add(fieldName, "", e.Error())
+					errs.Add([]string{fieldName}, "", e.Error())
 				}
 			}
 

--- a/errors.go
+++ b/errors.go
@@ -11,41 +11,46 @@ import (
 type (
 	// Errors may be generated during deserialization, binding,
 	// or validation. It implements the built-in error interface.
-	Errors []Error
+	Errors []FieldError
 
 	// Error is a powerful implementation of the built-in error
 	// interface that allows for error classification, custom error
 	// messages associated with specific fields, or with no
 	// associations at all.
-	Error struct {
-		// An error supports zero or more field names, because an
-		// error can morph three ways: (1) it can indicate something
-		// wrong with the request as a whole, (2) it can point to a
-		// specific problem with a particular input field, or (3) it
-		// can span multiple related input fields.
-		FieldNames []string `json:"fieldNames,omitempty"`
+	fieldError struct {
+		// An error supports a field names because an
+		// error can morph two ways: (1) it can indicate something
+		// wrong with the request as a whole, or (2) it can point to a
+		// specific problem with a particular input field.
+		fieldName string `json:"fieldNames,omitempty"`
 
 		// The classification is like an error code, convenient to
 		// use when processing or categorizing an error programmatically.
 		// It may also be called the "kind" of error.
-		Classification string `json:"classification,omitempty"`
+		classification string `json:"classification,omitempty"`
 
 		// Message should be human-readable and detailed enough to
 		// pinpoint and resolve the problem, but it should be brief. For
 		// example, a payload of 100 objects in a JSON array might have
 		// an error in the 41st object. The message should help the
 		// end user find and fix the error with their request.
-		Message string `json:"message,omitempty"`
+		message string `json:"message,omitempty"`
+	}
+
+	FieldError interface {
+		error
+		Field() string
+		Kind() string
 	}
 )
 
-// Add adds an error associated with the fields indicated
-// by fieldNames, with the given classification and message.
-func (e *Errors) Add(fieldNames []string, classification, message string) {
-	*e = append(*e, Error{
-		FieldNames:     fieldNames,
-		Classification: classification,
-		Message:        message,
+// Add adds an fieldError associated with the field indicated
+// by fieldName, with the given classification and message.
+func (e *Errors) Add(fieldName string, classification, message string) {
+	*e = append(*e, fieldError{
+		fieldName:      fieldName,
+		classification: classification,
+		message:        message,
 	})
 }
 
@@ -54,7 +59,7 @@ func (e *Errors) Len() int {
 	return len(*e)
 }
 
-// Has determines whether an Errors slice has an Error with
+// Has determines whether an e has an Error with
 // a given classification in it; it does not search on messages
 // or field names.
 func (e *Errors) Has(class string) bool {
@@ -70,7 +75,7 @@ func (e *Errors) Has(class string) bool {
 // are contained, and it will return true. Otherwise, nothing happens
 // and false is returned.
 // (The value receiver is due to issue 8: https://github.com/mholt/binding/issues/8)
-func (e Errors) Handle(response http.ResponseWriter) bool {
+func (e *Errors) Handle(response http.ResponseWriter) bool {
 	if e.Len() > 0 {
 		response.Header().Set("Content-Type", jsonContentType)
 		if e.Has(DeserializationError) {
@@ -98,18 +103,18 @@ func (e Errors) Error() string {
 
 // Fields returns the list of field names this error is
 // associated with.
-func (e Error) Fields() []string {
-	return e.FieldNames
+func (e fieldError) Field() string {
+	return e.fieldName
 }
 
 // Kind returns this error's classification.
-func (e Error) Kind() string {
-	return e.Classification
+func (e fieldError) Kind() string {
+	return e.classification
 }
 
 // Error returns this error's message.
-func (e Error) Error() string {
-	return e.Message
+func (e fieldError) Error() string {
+	return e.message
 }
 
 const (

--- a/errors.go
+++ b/errors.go
@@ -127,7 +127,7 @@ func (e fieldsError) Error() string {
 		fields[i] = fmt.Sprintf("* %s", f)
 	}
 
-	return fmt.Sprintf("%s\n\n%s", e.message, strings.Join(fields, "\n"))
+	return fmt.Sprintf("%s\n\t%s", e.message, strings.Join(fields, "\n\t"))
 }
 
 func (e fieldsError) MarshalJSON() ([]byte, error) {

--- a/errors.go
+++ b/errors.go
@@ -9,7 +9,7 @@ import (
 
 type (
 	// Errors may be generated during deserialization, binding,
-	// or validation. It implements the built-in error interface.
+	// or validation.
 	Errors []Error
 
 	// An Error is an error that is associated with 0 or more fields of a

--- a/errors.go
+++ b/errors.go
@@ -55,7 +55,7 @@ type (
 // the given kind and message.
 //
 // Use a fieldNames value of length 0 to indicate that the error is about the
-// request as a whole, and not necessary any of the fields.
+// request as a whole, and not necessarily any of the fields.
 //
 // kind should be a string that can be used like an error code to process or
 // categorize the error being added.

--- a/errors.go
+++ b/errors.go
@@ -13,16 +13,13 @@ type (
 	// or validation. It implements the built-in error interface.
 	Errors []FieldError
 
-	// Error is a powerful implementation of the built-in error
-	// interface that allows for error classification, custom error
-	// messages associated with specific fields, or with no
-	// associations at all.
-	fieldError struct {
-		// An error supports a field names because an
-		// error can morph two ways: (1) it can indicate something
-		// wrong with the request as a whole, or (2) it can point to a
-		// specific problem with a particular input field.
-		fieldName string `json:"fieldNames,omitempty"`
+	fieldsError struct {
+		// A fieldError supports zero or more field names, because an
+		// error can morph three ways: (1) it can indicate something
+		// wrong with the request as a whole, (2) it can point to a
+		// specific problem with a particular input field, or (3) it
+		// can span multiple related input fields.
+		fieldNames []string `json:"fieldNames,omitempty"`
 
 		// The classification is like an error code, convenient to
 		// use when processing or categorizing an error programmatically.
@@ -37,18 +34,22 @@ type (
 		message string `json:"message,omitempty"`
 	}
 
+	// FieldError is a powerful implementation of the built-in error
+	// interface that allows for error classification, custom error
+	// messages associated with specific fields, or with no
+	// associations at all.
 	FieldError interface {
 		error
-		Field() string
+		Fields() []string
 		Kind() string
 	}
 )
 
 // Add adds an fieldError associated with the field indicated
 // by fieldName, with the given classification and message.
-func (e *Errors) Add(fieldName string, classification, message string) {
-	*e = append(*e, fieldError{
-		fieldName:      fieldName,
+func (e *Errors) Add(fieldNames []string, classification, message string) {
+	*e = append(*e, fieldsError{
+		fieldNames:     fieldNames,
 		classification: classification,
 		message:        message,
 	})
@@ -103,17 +104,17 @@ func (e Errors) Error() string {
 
 // Fields returns the list of field names this error is
 // associated with.
-func (e fieldError) Field() string {
-	return e.fieldName
+func (e fieldsError) Fields() []string {
+	return e.fieldNames[:]
 }
 
 // Kind returns this error's classification.
-func (e fieldError) Kind() string {
+func (e fieldsError) Kind() string {
 	return e.classification
 }
 
 // Error returns this error's message.
-func (e fieldError) Error() string {
+func (e fieldsError) Error() string {
 	return e.message
 }
 

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,9 @@
 package binding
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // This file shamelessly adapted from martini-contrib/binding
 
@@ -9,22 +12,29 @@ type (
 	// or validation. It implements the built-in error interface.
 	Errors []Error
 
-	// FieldError is a powerful implementation of the built-in error
-	// interface that allows for error classification, custom error
-	// messages associated with specific fields, or with no
-	// associations at all.
+	// An Error is an error that is associated with 0 or more fields of a
+	// request.
+	//
+	// Fields should return the fields associated with the error. When the return
+	// value's length is 0, something is wrong with the request as a whole.
+	//
+	// Kind should return a string that can be used like an error code to process
+	// or categorize the Error.
+	//
+	// Message should return the error message.
 	Error interface {
 		error
 		Fields() []string
 		Kind() string
+		Message() string
 	}
 
 	fieldsError struct {
-		// A fieldError supports zero or more field names, because an
-		// error can morph three ways: (1) it can indicate something
-		// wrong with the request as a whole, (2) it can point to a
-		// specific problem with a particular input field, or (3) it
-		// can span multiple related input fields.
+		// A fieldError supports zero or more field names, because an error can
+		// morph three ways:
+		// 		* it can indicate something wrong with the request as a whole.
+		//		* it can point to a specific problem with a particular input field
+		//		* it can span multiple related input fields.
 		fieldNames []string `json:"fieldNames,omitempty"`
 
 		// The classification is like an error code, convenient to
@@ -41,12 +51,23 @@ type (
 	}
 )
 
-// Add adds an fieldError associated with the field indicated
-// by fieldName, with the given classification and message.
-func (e *Errors) Add(fieldNames []string, classification, message string) {
+// Add adds an Error associated with the fields indicated by fieldNames, with
+// the given kind and message.
+//
+// Use a fieldNames value of length 0 to indicate that the error is about the
+// request as a whole, and not necessary any of the fields.
+//
+// kind should be a string that can be used like an error code to process or
+// categorize the error being added.
+//
+// message should be human-readable and detailed enough to pinpoint and resolve
+// the problem, but it should be brief. For example, a payload of 100 objects
+// in a JSON array might have an error in the 41st object. The message should
+// help the end user find and fix the error with their request.
+func (e *Errors) Add(fieldNames []string, kind, message string) {
 	*e = append(*e, fieldsError{
 		fieldNames:     fieldNames,
-		classification: classification,
+		classification: kind,
 		message:        message,
 	})
 }
@@ -56,12 +77,11 @@ func (e *Errors) Len() int {
 	return len(*e)
 }
 
-// Has determines whether an e has an Error with
-// a given classification in it; it does not search on messages
-// or field names.
-func (e *Errors) Has(class string) bool {
+// Has determines whether kind matches the return value of Kind() of any Error
+// in e.
+func (e *Errors) Has(kind string) bool {
 	for _, err := range *e {
-		if err.Kind() == class {
+		if err.Kind() == kind {
 			return true
 		}
 	}
@@ -72,25 +92,37 @@ func (e *Errors) Has(class string) bool {
 func (e Errors) Error() string {
 	messages := []string{}
 	for _, err := range e {
-		messages = append(messages, err.Error())
+		messages = append(messages, err.Message())
 	}
-	return strings.Join(messages, ", ")
+	return strings.Join(messages, "\n")
 }
 
-// Fields returns the list of field names this error is
-// associated with.
+// Fields returns the list of field names associated with e.
 func (e fieldsError) Fields() []string {
-	return e.fieldNames[:]
+	return e.fieldNames
 }
 
-// Kind returns this error's classification.
+// Kind returns a string that can be used to categorize e.
 func (e fieldsError) Kind() string {
 	return e.classification
 }
 
-// Error returns this error's message.
-func (e fieldsError) Error() string {
+// Message returns the message of e.
+func (e fieldsError) Message() string {
 	return e.message
+}
+
+func (e fieldsError) Error() string {
+	if len(e.fieldNames) == 0 {
+		return e.message
+	}
+
+	fields := make([]string, len(e.fieldNames))
+	for i, f := range e.fieldNames {
+		fields[i] = fmt.Sprintf("* %s", f)
+	}
+
+	return fmt.Sprintf("%s\n\n%s", e.message, strings.Join(fields, "\n"))
 }
 
 const (

--- a/errors.go
+++ b/errors.go
@@ -65,11 +65,7 @@ type (
 // in a JSON array might have an error in the 41st object. The message should
 // help the end user find and fix the error with their request.
 func (e *Errors) Add(fieldNames []string, kind, message string) {
-	*e = append(*e, fieldsError{
-		fieldNames:     fieldNames,
-		classification: kind,
-		message:        message,
-	})
+	*e = append(*e, NewError(fieldNames, kind, message))
 }
 
 // Len returns the number of errors.
@@ -95,6 +91,14 @@ func (e Errors) Error() string {
 		messages = append(messages, err.Message())
 	}
 	return strings.Join(messages, "\n")
+}
+
+func NewError(fieldNames []string, kind, message string) Error {
+	return fieldsError{
+		fieldNames:     fieldNames,
+		classification: kind,
+		message:        message,
+	}
 }
 
 // Fields returns the list of field names associated with e.

--- a/errors.go
+++ b/errors.go
@@ -35,19 +35,19 @@ type (
 		// 		* it can indicate something wrong with the request as a whole.
 		//		* it can point to a specific problem with a particular input field
 		//		* it can span multiple related input fields.
-		fieldNames []string `json:"fieldNames,omitempty"`
+		fields []string
 
 		// The classification is like an error code, convenient to
 		// use when processing or categorizing an error programmatically.
 		// It may also be called the "kind" of error.
-		classification string `json:"classification,omitempty"`
+		kind string
 
 		// Message should be human-readable and detailed enough to
 		// pinpoint and resolve the problem, but it should be brief. For
 		// example, a payload of 100 objects in a JSON array might have
 		// an error in the 41st object. The message should help the
 		// end user find and fix the error with their request.
-		message string `json:"message,omitempty"`
+		message string
 	}
 )
 
@@ -95,20 +95,20 @@ func (e Errors) Error() string {
 
 func NewError(fieldNames []string, kind, message string) Error {
 	return fieldsError{
-		fieldNames:     fieldNames,
-		classification: kind,
-		message:        message,
+		fields:  fieldNames,
+		kind:    kind,
+		message: message,
 	}
 }
 
-// Fields returns the list of field names associated with e.
+// Fields returns the names of the fields associated with e.
 func (e fieldsError) Fields() []string {
-	return e.fieldNames
+	return e.fields
 }
 
 // Kind returns a string that can be used to categorize e.
 func (e fieldsError) Kind() string {
-	return e.classification
+	return e.kind
 }
 
 // Message returns the message of e.
@@ -117,12 +117,12 @@ func (e fieldsError) Message() string {
 }
 
 func (e fieldsError) Error() string {
-	if len(e.fieldNames) == 0 {
+	if len(e.fields) == 0 {
 		return e.message
 	}
 
-	fields := make([]string, len(e.fieldNames))
-	for i, f := range e.fieldNames {
+	fields := make([]string, len(e.fields))
+	for i, f := range e.fields {
 		fields[i] = fmt.Sprintf("* %s", f)
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,7 @@
 package binding
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -127,6 +128,18 @@ func (e fieldsError) Error() string {
 	}
 
 	return fmt.Sprintf("%s\n\n%s", e.message, strings.Join(fields, "\n"))
+}
+
+func (e fieldsError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		FieldNames     []string `json:"fieldNames,omitempty"`
+		Classification string   `json:"classification,omitempty"`
+		Message        string   `json:"message,omitempty"`
+	}{
+		FieldNames:     e.fields,
+		Classification: e.kind,
+		Message:        e.message,
+	})
 }
 
 const (

--- a/errors.go
+++ b/errors.go
@@ -1,10 +1,6 @@
 package binding
 
-import (
-	"encoding/json"
-	"net/http"
-	"strings"
-)
+import "strings"
 
 // This file shamelessly adapted from martini-contrib/binding
 
@@ -68,27 +64,6 @@ func (e *Errors) Has(class string) bool {
 		if err.Kind() == class {
 			return true
 		}
-	}
-	return false
-}
-
-// Handle writes the errors to response in JSON form if any errors
-// are contained, and it will return true. Otherwise, nothing happens
-// and false is returned.
-// (The value receiver is due to issue 8: https://github.com/mholt/binding/issues/8)
-func (e *Errors) Handle(response http.ResponseWriter) bool {
-	if e.Len() > 0 {
-		response.Header().Set("Content-Type", jsonContentType)
-		if e.Has(DeserializationError) {
-			response.WriteHeader(http.StatusBadRequest)
-		} else if e.Has(ContentTypeError) {
-			response.WriteHeader(http.StatusUnsupportedMediaType)
-		} else {
-			response.WriteHeader(StatusUnprocessableEntity)
-		}
-		errOutput, _ := json.Marshal(e)
-		response.Write(errOutput)
-		return true
 	}
 	return false
 }

--- a/errors.go
+++ b/errors.go
@@ -11,7 +11,17 @@ import (
 type (
 	// Errors may be generated during deserialization, binding,
 	// or validation. It implements the built-in error interface.
-	Errors []FieldError
+	Errors []Error
+
+	// FieldError is a powerful implementation of the built-in error
+	// interface that allows for error classification, custom error
+	// messages associated with specific fields, or with no
+	// associations at all.
+	Error interface {
+		error
+		Fields() []string
+		Kind() string
+	}
 
 	fieldsError struct {
 		// A fieldError supports zero or more field names, because an
@@ -32,16 +42,6 @@ type (
 		// an error in the 41st object. The message should help the
 		// end user find and fix the error with their request.
 		message string `json:"message,omitempty"`
-	}
-
-	// FieldError is a powerful implementation of the built-in error
-	// interface that allows for error classification, custom error
-	// messages associated with specific fields, or with no
-	// associations at all.
-	FieldError interface {
-		error
-		Fields() []string
-		Kind() string
 	}
 )
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -6,6 +6,11 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+var _ error = &fieldsError{}
+var _ error = Errors{}
+var _ error = *new(Error)
+var _ Error = &fieldsError{}
+
 func TestErrorAdd(t *testing.T) {
 
 	Convey("When using Add to add an error to the slice", t, func() {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,6 +1,7 @@
 package binding
 
 import (
+	"encoding/json"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -10,6 +11,7 @@ var _ error = &fieldsError{}
 var _ error = Errors{}
 var _ error = *new(Error)
 var _ Error = &fieldsError{}
+var _ json.Marshaler = fieldsError{}
 
 func TestErrorAdd(t *testing.T) {
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -17,7 +17,7 @@ func TestValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 			model := NewCompleteModel()
-			errs := Validate(req, &model)
+			errs := validate(req, &model)
 
 			expectedErrs := make(map[string]bool)
 			for _, v := range model.FieldMap() {
@@ -30,10 +30,8 @@ func TestValidate(t *testing.T) {
 			}
 
 			for _, bindErr := range errs {
-				for _, name := range bindErr.FieldNames {
-					if bindErr.Classification == RequiredError {
-						expectedErrs[name] = true
-					}
+				if bindErr.Kind() == RequiredError {
+					expectedErrs[bindErr.Field()] = true
 				}
 			}
 
@@ -63,7 +61,7 @@ func TestValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 			model := new(AllTypes)
-			errs := Validate(req, model)
+			errs := validate(req, model)
 
 			expectedErrs := make(map[string]bool)
 			for _, v := range model.FieldMap() {
@@ -76,10 +74,8 @@ func TestValidate(t *testing.T) {
 			}
 
 			for _, bindErr := range errs {
-				for _, name := range bindErr.FieldNames {
-					if bindErr.Classification == RequiredError {
-						expectedErrs[name] = true
-					}
+				if bindErr.Kind() == RequiredError {
+					expectedErrs[bindErr.Field()] = true
 				}
 			}
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -31,7 +31,9 @@ func TestValidate(t *testing.T) {
 
 			for _, bindErr := range errs {
 				if bindErr.Kind() == RequiredError {
-					expectedErrs[bindErr.Field()] = true
+					for _, name := range bindErr.Fields() {
+						expectedErrs[name] = true
+					}
 				}
 			}
 
@@ -75,7 +77,9 @@ func TestValidate(t *testing.T) {
 
 			for _, bindErr := range errs {
 				if bindErr.Kind() == RequiredError {
-					expectedErrs[bindErr.Field()] = true
+					for _, name := range bindErr.Fields() {
+						expectedErrs[name] = true
+					}
 				}
 			}
 


### PR DESCRIPTION
Consider this a proposal to fix #22. I believe these changes represent a more idiomatic approach, but I welcome any feedback. Obviously, this breaks compatibility with previous releases. Once we reach an agreement on changes, I'll update README.md before we merge.

Return error types from exported functions

Change the Binder function type, Binder.Bind, and Validator.Validate to
have an error return value and modify their parameters to no longer
include the slice of errors.

Flatten field errors. Each error is associated with at most one field.

Stop exporting Error. Replace it with a new interface type, FieldError,
and rename Error to fieldError.
