### PR TITLE
give Binders defined in fieldspec a higher precedence than Bind methods

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -356,6 +356,11 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 		_, isFileSlice := fieldPointer.(*[]**multipart.FileHeader)
 		strs := formData[fieldName]
 
+		if fieldSpec.Binder != nil {
+			errs = fieldSpec.Binder(fieldName, strs, errs)
+			continue
+		}
+
 		if !isFile && !isFileSlice {
 			if len(strs) == 0 {
 				continue
@@ -370,11 +375,6 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 			if err != nil {
 				errs.Add([]string{fieldName}, TypeError, err.Error())
 			}
-		}
-
-		if fieldSpec.Binder != nil {
-			errs = fieldSpec.Binder(fieldName, strs, errs)
-			continue
 		}
 
 		switch t := fieldPointer.(type) {


### PR DESCRIPTION
This is a PR to address the expected behavior I outlined in https://github.com/mholt/binding/issues/44 in case my expectation seems reasonable.