### PR TITLE
Pass the errors accumulated during binding to the validate method

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -41,7 +41,7 @@ func Bind(req *http.Request, userStruct FieldMapper) Errors {
 			return Form(req, userStruct)
 		} else {
 			errs.Add([]string{}, ContentTypeError, "Empty Content-Type")
-			errs = append(errs, Validate(req, userStruct)...)
+			errs = Validate(errs, req, userStruct)
 		}
 	} else {
 		errs.Add([]string{}, ContentTypeError, "Unsupported Content-Type")
@@ -123,7 +123,7 @@ func defaultJsonBinder(req *http.Request, userStruct FieldMapper) Errors {
 		return errs
 	}
 
-	errs = append(errs, Validate(req, userStruct)...)
+	errs = Validate(errs, req, userStruct)
 
 	return errs
 }
@@ -131,9 +131,7 @@ func defaultJsonBinder(req *http.Request, userStruct FieldMapper) Errors {
 // Validate ensures that all conditions have been met on every field in the
 // populated struct. Validation should occur after the request has been
 // deserialized into the struct.
-func Validate(req *http.Request, userStruct FieldMapper) Errors {
-	var errs Errors
-
+func Validate(errs Errors, req *http.Request, userStruct FieldMapper) Errors {
 	fm := userStruct.FieldMap(req)
 
 	for fieldPointer, fieldNameOrSpec := range fm {
@@ -663,7 +661,7 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 
 	}
 
-	errs = append(errs, Validate(req, userStruct)...)
+	errs = Validate(errs, req, userStruct)
 
 	return errs
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -17,7 +17,8 @@ func TestValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 			model := NewCompleteModel()
-			errs := Validate(req, &model)
+			var errs Errors
+			errs = Validate(errs, req, &model)
 
 			expectedErrs := make(map[string]bool)
 			for _, v := range model.FieldMap(nil) {
@@ -63,7 +64,8 @@ func TestValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 			model := new(AllTypes)
-			errs := Validate(req, model)
+			var errs Errors
+			errs = Validate(errs, req, model)
 
 			expectedErrs := make(map[string]bool)
 			for _, v := range model.FieldMap(nil) {


### PR DESCRIPTION
This attempts to address the issue outlined in https://github.com/mholt/binding/issues/46
