### PR TITLE
URL method dedicated for query string binding

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -70,6 +70,8 @@ func defaultFormBinder(req *http.Request, userStruct FieldMapper) Errors {
 	return bindForm(req, userStruct, req.Form, nil, errs)
 }
 
+// URL reads data out of the query string into a struct you provide.
+// This function invokes data validation after deserialization.
 func URL(req *http.Request, userStruct FieldMapper) Errors {
 	return urlBinder(req, userStruct)
 }

--- a/binding.go
+++ b/binding.go
@@ -70,6 +70,18 @@ func defaultFormBinder(req *http.Request, userStruct FieldMapper) Errors {
 	return bindForm(req, userStruct, req.Form, nil, errs)
 }
 
+func URL(req *http.Request, userStruct FieldMapper) Errors {
+	return urlBinder(req, userStruct)
+}
+
+var urlBinder requestBinder = defaultURLBinder
+
+func defaultURLBinder(req *http.Request, userStruct FieldMapper) Errors {
+	var errs Errors
+	
+	return bindForm(req, userStruct, req.URL.Query(), nil, errs)
+}
+
 // MultipartForm reads a multipart form request and deserializes its data and
 // files into a struct you provide. Files should be deserialized into
 // *multipart.FileHeader fields.


### PR DESCRIPTION
I did not like that `http.Request.ParseForm` has some conditions where it would not parse the query string, so I added a new method to always bind from the URL.
