### PR TITLE
If request does not have header with Content-Type, it will be parsed as form-urlencoded request.

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -23,6 +23,9 @@ func Bind(req *http.Request, userStruct FieldMapper) Errors {
 	var errs Errors
 
 	contentType := req.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "form-urlencoded"
+	}
 
 	if strings.Contains(contentType, "form-urlencoded") {
 		return Form(req, userStruct)
@@ -36,16 +39,7 @@ func Bind(req *http.Request, userStruct FieldMapper) Errors {
 		return Json(req, userStruct)
 	}
 
-	if contentType == "" {
-		if len(req.URL.Query()) > 0 {
-			return Form(req, userStruct)
-		} else {
-			errs.Add([]string{}, ContentTypeError, "Empty Content-Type")
-			errs = Validate(errs, req, userStruct)
-		}
-	} else {
-		errs.Add([]string{}, ContentTypeError, "Unsupported Content-Type")
-	}
+	errs.Add([]string{}, ContentTypeError, "Unsupported Content-Type")
 
 	return errs
 }

--- a/binding_test.go
+++ b/binding_test.go
@@ -56,7 +56,7 @@ func TestBind(t *testing.T) {
 
 			Convey("And without a query string", func() {
 
-				Convey("Should yield an error", nil)
+				Convey("Should invoke the Form deserializer", nil)
 
 			})
 


### PR DESCRIPTION
Most http clients do not add "Content-Type" header to the GET request by default. In some cases I want to accept GET request without any query params ( empty filters for resource for example), therefore the request should be still parsed and I will get empty struct after parsing. Request also may be PATCH without any data to update. 