### PR TITLE
Make []Error.Errors() useful with RequiredError

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -107,7 +107,7 @@ func (e Error) Kind() string {
 
 // Error returns this error's message.
 func (e Error) Error() string {
-	return e.Message
+	return e.Message + ": " + strings.Join(e.FieldNames, ", ")
 }
 
 const (


### PR DESCRIPTION
When handling user input that lacks required fields, simply attempting to use `[]Error.Errors()` results in an error message that looks like `Required, Required` without showing which fields are required.

This change makes it so that you always know *what* field is required when you get each `err.Error()`, and makes `[]Error.Errors()` actually useful.