### PR TITLE
Actually require multipart file fields

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -378,6 +378,10 @@ func validate(errs Errors, req *http.Request, userStruct FieldMapper) Errors {
 				if len(*t) == 0 {
 					addRequiredError()
 				}
+			case **multipart.FileHeader:
+				if *t == nil {
+					addRequiredError()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Without this patch, the `Required: true` field is ineffective given a definition like this:

```go
type T struct {
	file  *multipart.FileHeader
}

func (t *T) FieldMap(req *http.Request) binding.FieldMap {
	return binding.FieldMap{
		&p.file: binding.Field{
			Form:     "file",
			Required: true,
		},
	}
}
```

I don't know if there's a reason for this case to be absent.