### PR TITLE
fix Field.Bind usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ For types you've defined, you can bind form data to it by implementing the `Bind
 
 
 ```go
-type MyType map[string]string
+type MyBinder map[string]string
 
-func (t MyType) Bind(fieldName string, strVals []string) error {
+func (t MyBinder) Bind(fieldName string, strVals []string) error {
 	t["formData"] = strVals[0]
 	return nil
 }
@@ -189,9 +189,10 @@ func (t MyType) Bind(fieldName string, strVals []string) error {
 If you can't add a method to the type, you can still specify a `Binder` func in the field spec. Here's a contrived example that binds an integer (not necessary, but you get the idea):
 
 ```go
-func (t *MyType) FieldMap() binding.FieldMap {
+func (t *MyType) FieldMap(req *http.Request) binding.FieldMap {
 	return binding.FieldMap{
-		"number": binding.Field{
+		"a-key": binding.Field{
+			Form: "number",
 			Binder: func(fieldName string, formVals []string) error {
 				val, err := strconv.Atoi(formVals[0])
 				if err != nil {

--- a/binder_test.go
+++ b/binder_test.go
@@ -1,0 +1,55 @@
+package binding_test
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+
+	"github.com/mholt/binding"
+)
+
+type MyBinder map[string]string
+
+func (t MyBinder) Bind(fieldName string, strVals []string) error {
+	t["formData"] = strVals[0]
+	return nil
+}
+
+type MyBinderContainer struct {
+	Important MyBinder
+}
+
+func (c *MyBinderContainer) FieldMap(req *http.Request) binding.FieldMap {
+	return binding.FieldMap{
+		&c.Important: "important",
+	}
+}
+
+func ExampleBinder() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		v := new(MyBinderContainer)
+		v.Important = make(MyBinder)
+		if err := binding.Bind(req, v); err != nil {
+			w.WriteHeader(500)
+			w.Write([]byte(err.Error()))
+			return
+		}
+		fmt.Fprintf(w, v.Important["formData"])
+	}))
+	defer ts.Close()
+
+	resp, err := http.DefaultClient.PostForm(ts.URL, url.Values{"important": []string{"1008"}})
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	defer resp.Body.Close()
+
+	io.Copy(os.Stdout, resp.Body)
+
+	// Output: 1008
+}

--- a/binding.go
+++ b/binding.go
@@ -415,7 +415,6 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 	fm := userStruct.FieldMap(req)
 
 	for fieldPointer, fieldNameOrSpec := range fm {
-
 		fieldSpec, err := fieldSpecification(fieldNameOrSpec)
 		if err != nil {
 			continue
@@ -426,10 +425,6 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 		_, isFileSlice := fieldPointer.(*[]*multipart.FileHeader)
 
 		if !isFile && !isFileSlice {
-			if len(strs) == 0 {
-				continue
-			}
-
 			if fieldSpec.Binder != nil {
 				err := fieldSpec.Binder(fieldSpec.Form, strs)
 				if err != nil {
@@ -444,6 +439,7 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 				}
 				continue
 			}
+
 			if binder, ok := fieldPointer.(Binder); ok {
 				err := binder.Bind(fieldSpec.Form, strs)
 				if err != nil {
@@ -456,6 +452,10 @@ func bindForm(req *http.Request, userStruct FieldMapper, formData map[string][]s
 						errs.Add([]string{fieldSpec.Form}, "", e.Error())
 					}
 				}
+				continue
+			}
+
+			if len(strs) == 0 {
 				continue
 			}
 		}

--- a/fieldbinder_test.go
+++ b/fieldbinder_test.go
@@ -1,0 +1,58 @@
+package binding_test
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/mholt/binding"
+)
+
+type MyType struct {
+	SomeNumber int
+}
+
+func (t *MyType) FieldMap(req *http.Request) binding.FieldMap {
+	return binding.FieldMap{
+		"a-key": binding.Field{
+			Form: "number",
+			Binder: func(fieldName string, formVals []string) error {
+				val, err := strconv.Atoi(formVals[0])
+				if err != nil {
+					return binding.Errors{binding.NewError([]string{fieldName}, binding.DeserializationError, err.Error())}
+				}
+				t.SomeNumber = val
+				return nil
+			},
+		},
+	}
+}
+
+func Example_fieldBinder() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b := new(MyType)
+		if err := binding.Bind(req, b); err != nil {
+			w.WriteHeader(500)
+			w.Write([]byte(err.Error()))
+			return
+		}
+		fmt.Fprintf(w, "%d", b.SomeNumber)
+	}))
+	defer ts.Close()
+
+	resp, err := http.DefaultClient.PostForm(ts.URL, url.Values{"number": []string{"1008"}})
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	defer resp.Body.Close()
+
+	io.Copy(os.Stdout, resp.Body)
+
+	// Output: 1008
+}


### PR DESCRIPTION
Fix the usage of Field.Bind so that the field name is taken from the
field specification.

Correct README.md's example of using Field.Bind.

Add testable examples of Field.Bind and Binder and sync the testable
examples with the examples in README.md.

Fixes #55.