### PR TITLE
Don't convert non-binding.Errors.

### DIFF
--- a/validate_test.go
+++ b/validate_test.go
@@ -18,7 +18,7 @@ func TestValidate(t *testing.T) {
 			}
 			model := NewCompleteModel()
 			var errs Errors
-			errs = validate(errs, req, &model)
+			errs = validate(errs, req, &model).(Errors)
 
 			expectedErrs := make(map[string]bool)
 			for _, v := range model.FieldMap(nil) {
@@ -65,7 +65,7 @@ func TestValidate(t *testing.T) {
 			}
 			model := new(AllTypes)
 			var errs Errors
-			errs = validate(errs, req, model)
+			errs = validate(errs, req, model).(Errors)
 
 			expectedErrs := make(map[string]bool)
 			for _, v := range model.FieldMap(nil) {


### PR DESCRIPTION
As a follow-on to 52f4dd9, continue the process of allowing errors that
aren't binding.Errors to flow through without adaptation.

The need for this arises from cases where validation is performed
against a struct that contains field of a struct type that also
implements Validator, when the validation for the inner type returns an
error that isn't a binding.Errors. The existing code consumes such
errors and turns them into not-particularly-helpful binding.Errors
instances, inhibiting upstack processing of distinct error types. This
does away with that interference.